### PR TITLE
Add TypeScript watch mode for development

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,22 @@ PATH
   remote: .
   specs:
     t_ruby (0.0.1)
+      listen (~> 3.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.6.2)
     docile (1.4.1)
+    ffi (1.17.2)
+    ffi (1.17.2-x86_64-linux-gnu)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)

--- a/lib/t_ruby.rb
+++ b/lib/t_ruby.rb
@@ -13,6 +13,7 @@ require_relative "t_ruby/rbs_generator"
 require_relative "t_ruby/declaration_generator"
 require_relative "t_ruby/compiler"
 require_relative "t_ruby/lsp_server"
+require_relative "t_ruby/watcher"
 require_relative "t_ruby/cli"
 
 module TRuby

--- a/lib/t_ruby/cli.rb
+++ b/lib/t_ruby/cli.rb
@@ -7,6 +7,7 @@ module TRuby
 
       Usage:
         trc <file.trb>           Compile a .trb file to .rb
+        trc --watch, -w          Watch input files and recompile on change
         trc --decl <file.trb>    Generate .d.trb declaration file
         trc --lsp                Start LSP server (for IDE integration)
         trc --version, -v        Show version
@@ -14,6 +15,9 @@ module TRuby
 
       Examples:
         trc hello.trb            Compile hello.trb to build/hello.rb
+        trc -w                   Watch all .trb files in current directory
+        trc -w src/              Watch all .trb files in src/ directory
+        trc --watch hello.trb    Watch specific file for changes
         trc --decl hello.trb     Generate hello.d.trb declaration file
         trc --lsp                Start language server for VS Code
     HELP
@@ -42,6 +46,11 @@ module TRuby
         return
       end
 
+      if @args.include?("--watch") || @args.include?("-w")
+        start_watch_mode
+        return
+      end
+
       if @args.include?("--decl")
         input_file = @args[@args.index("--decl") + 1]
         generate_declaration(input_file)
@@ -57,6 +66,19 @@ module TRuby
     def start_lsp_server
       server = LSPServer.new
       server.run
+    end
+
+    def start_watch_mode
+      # Get paths to watch (everything after --watch or -w flag)
+      watch_index = @args.index("--watch") || @args.index("-w")
+      paths = @args[(watch_index + 1)..]
+
+      # Default to current directory if no paths specified
+      paths = ["."] if paths.empty?
+
+      config = Config.new
+      watcher = Watcher.new(paths: paths, config: config)
+      watcher.watch
     end
 
     def generate_declaration(input_file)

--- a/lib/t_ruby/watcher.rb
+++ b/lib/t_ruby/watcher.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "listen"
+
+module TRuby
+  class Watcher
+    # ANSI color codes (similar to tsc output style)
+    COLORS = {
+      reset: "\e[0m",
+      bold: "\e[1m",
+      dim: "\e[2m",
+      red: "\e[31m",
+      green: "\e[32m",
+      yellow: "\e[33m",
+      blue: "\e[34m",
+      cyan: "\e[36m",
+      gray: "\e[90m"
+    }.freeze
+
+    def initialize(paths: ["."], config: nil)
+      @paths = paths.map { |p| File.expand_path(p) }
+      @config = config || Config.new
+      @compiler = Compiler.new(@config)
+      @error_count = 0
+      @file_count = 0
+      @use_colors = $stdout.tty?
+    end
+
+    def watch
+      print_start_message
+
+      # Initial compilation
+      compile_all
+
+      # Start watching
+      listener = Listen.to(*watch_directories, only: /\.trb$/) do |modified, added, removed|
+        handle_changes(modified, added, removed)
+      end
+
+      listener.start
+
+      print_watching_message
+
+      # Keep the process running
+      begin
+        sleep
+      rescue Interrupt
+        puts "\n#{colorize(:dim, timestamp)} #{colorize(:cyan, "Stopping watch mode...")}"
+        listener.stop
+      end
+    end
+
+    private
+
+    def watch_directories
+      @paths.map do |path|
+        if File.directory?(path)
+          path
+        else
+          File.dirname(path)
+        end
+      end.uniq
+    end
+
+    def handle_changes(modified, added, removed)
+      changed_files = (modified + added).select { |f| f.end_with?(".trb") }
+      return if changed_files.empty? && removed.empty?
+
+      puts
+      print_file_change_message
+
+      if removed.any?
+        removed.each do |file|
+          puts "#{colorize(:gray, timestamp)} #{colorize(:yellow, "File removed:")} #{relative_path(file)}"
+        end
+      end
+
+      if changed_files.any?
+        compile_files(changed_files)
+      else
+        print_watching_message
+      end
+    end
+
+    def compile_all
+      @error_count = 0
+      @file_count = 0
+      errors = []
+
+      trb_files = find_trb_files
+      @file_count = trb_files.size
+
+      trb_files.each do |file|
+        result = compile_file(file)
+        errors.concat(result[:errors]) if result[:errors].any?
+      end
+
+      print_errors(errors)
+      print_summary
+    end
+
+    def compile_files(files)
+      @error_count = 0
+      @file_count = files.size
+      errors = []
+
+      files.each do |file|
+        result = compile_file(file)
+        errors.concat(result[:errors]) if result[:errors].any?
+      end
+
+      print_errors(errors)
+      print_summary
+      print_watching_message
+    end
+
+    def compile_file(file)
+      result = { file: file, errors: [], success: false }
+
+      begin
+        @compiler.compile(file)
+        result[:success] = true
+      rescue ArgumentError => e
+        @error_count += 1
+        result[:errors] << format_error(file, e.message)
+      rescue StandardError => e
+        @error_count += 1
+        result[:errors] << format_error(file, e.message)
+      end
+
+      result
+    end
+
+    def find_trb_files
+      files = []
+      @paths.each do |path|
+        if File.directory?(path)
+          files.concat(Dir.glob(File.join(path, "**", "*.trb")))
+        elsif File.file?(path) && path.end_with?(".trb")
+          files << path
+        end
+      end
+      files.uniq
+    end
+
+    def format_error(file, message)
+      # Parse error message for line/column info if available
+      # Format: file:line:col - error TRB0001: message
+      line = 1
+      col = 1
+
+      # Try to extract line info from error message
+      if message =~ /line (\d+)/i
+        line = ::Regexp.last_match(1).to_i
+      end
+
+      {
+        file: file,
+        line: line,
+        col: col,
+        message: message
+      }
+    end
+
+    def print_errors(errors)
+      errors.each do |error|
+        puts
+        # TypeScript-style error format: file:line:col - error TSXXXX: message
+        location = "#{colorize(:cyan, relative_path(error[:file]))}:#{colorize(:yellow, error[:line])}:#{colorize(:yellow, error[:col])}"
+        puts "#{location} - #{colorize(:red, "error")} #{colorize(:gray, "TRB0001")}: #{error[:message]}"
+      end
+    end
+
+    def print_start_message
+      puts "#{colorize(:gray, timestamp)} #{colorize(:bold, "Starting compilation in watch mode...")}"
+      puts
+    end
+
+    def print_file_change_message
+      puts "#{colorize(:gray, timestamp)} #{colorize(:bold, "File change detected. Starting incremental compilation...")}"
+      puts
+    end
+
+    def print_summary
+      puts
+      if @error_count.zero?
+        msg = "Found #{colorize(:green, "0 errors")}. Watching for file changes."
+        puts "#{colorize(:gray, timestamp)} #{msg}"
+      else
+        error_word = @error_count == 1 ? "error" : "errors"
+        msg = "Found #{colorize(:red, "#{@error_count} #{error_word}")}. Watching for file changes."
+        puts "#{colorize(:gray, timestamp)} #{msg}"
+      end
+    end
+
+    def print_watching_message
+      # Just print a blank line for readability
+    end
+
+    def timestamp
+      Time.now.strftime("[%I:%M:%S %p]")
+    end
+
+    def relative_path(file)
+      file.sub("#{Dir.pwd}/", "")
+    end
+
+    def colorize(color, text)
+      return text unless @use_colors
+      return text unless COLORS[color]
+
+      "#{COLORS[color]}#{text}#{COLORS[:reset]}"
+    end
+  end
+end

--- a/spec/t_ruby/watcher_spec.rb
+++ b/spec/t_ruby/watcher_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TRuby::Watcher do
+  describe "#initialize" do
+    it "initializes with default path" do
+      watcher = TRuby::Watcher.new
+      expect(watcher).to be_a(TRuby::Watcher)
+    end
+
+    it "accepts custom paths" do
+      watcher = TRuby::Watcher.new(paths: ["src/", "lib/"])
+      expect(watcher).to be_a(TRuby::Watcher)
+    end
+
+    it "accepts custom config" do
+      config = TRuby::Config.new
+      watcher = TRuby::Watcher.new(config: config)
+      expect(watcher).to be_a(TRuby::Watcher)
+    end
+  end
+
+  describe "COLORS constant" do
+    it "defines ANSI color codes" do
+      expect(TRuby::Watcher::COLORS).to include(:reset, :red, :green, :cyan)
+    end
+  end
+
+  describe "TypeScript-style output" do
+    let(:watcher) { TRuby::Watcher.new }
+
+    describe "#timestamp" do
+      it "returns time in [HH:MM:SS AM/PM] format" do
+        timestamp = watcher.send(:timestamp)
+        expect(timestamp).to match(/\[\d{2}:\d{2}:\d{2} [AP]M\]/)
+      end
+    end
+
+    describe "#relative_path" do
+      it "converts absolute path to relative" do
+        absolute_path = "#{Dir.pwd}/src/test.trb"
+        relative = watcher.send(:relative_path, absolute_path)
+        expect(relative).to eq("src/test.trb")
+      end
+
+      it "returns unchanged if not in current directory" do
+        other_path = "/other/path/test.trb"
+        relative = watcher.send(:relative_path, other_path)
+        expect(relative).to eq(other_path)
+      end
+    end
+
+    describe "#colorize" do
+      context "when output is not a TTY" do
+        before do
+          allow($stdout).to receive(:tty?).and_return(false)
+        end
+
+        it "returns plain text without ANSI codes" do
+          watcher_no_color = TRuby::Watcher.new
+          result = watcher_no_color.send(:colorize, :red, "error")
+          expect(result).to eq("error")
+          expect(result).not_to include("\e[")
+        end
+      end
+    end
+
+    describe "#format_error" do
+      it "returns error hash with file, line, col, and message" do
+        error = watcher.send(:format_error, "test.trb", "syntax error")
+
+        expect(error).to include(
+          file: "test.trb",
+          line: 1,
+          col: 1,
+          message: "syntax error"
+        )
+      end
+
+      it "extracts line number from error message if available" do
+        error = watcher.send(:format_error, "test.trb", "error on line 42")
+        expect(error[:line]).to eq(42)
+      end
+    end
+  end
+
+  describe "file discovery" do
+    describe "#find_trb_files" do
+      it "finds .trb files in specified directories" do
+        Dir.mktmpdir do |tmpdir|
+          # Create test files
+          File.write(File.join(tmpdir, "test1.trb"), "# test1")
+          File.write(File.join(tmpdir, "test2.trb"), "# test2")
+          File.write(File.join(tmpdir, "ignore.rb"), "# ignore")
+
+          watcher = TRuby::Watcher.new(paths: [tmpdir])
+          files = watcher.send(:find_trb_files)
+
+          expect(files.length).to eq(2)
+          expect(files.all? { |f| f.end_with?(".trb") }).to be true
+        end
+      end
+
+      it "finds .trb files in subdirectories" do
+        Dir.mktmpdir do |tmpdir|
+          subdir = File.join(tmpdir, "sub")
+          FileUtils.mkdir_p(subdir)
+          File.write(File.join(subdir, "nested.trb"), "# nested")
+
+          watcher = TRuby::Watcher.new(paths: [tmpdir])
+          files = watcher.send(:find_trb_files)
+
+          expect(files.length).to eq(1)
+          expect(files.first).to include("nested.trb")
+        end
+      end
+
+      it "handles single file path" do
+        Dir.mktmpdir do |tmpdir|
+          file_path = File.join(tmpdir, "single.trb")
+          File.write(file_path, "# single")
+
+          watcher = TRuby::Watcher.new(paths: [file_path])
+          files = watcher.send(:find_trb_files)
+
+          expect(files).to eq([file_path])
+        end
+      end
+    end
+  end
+
+  describe "compilation" do
+    describe "#compile_file" do
+      it "returns success result for valid file" do
+        Dir.mktmpdir do |tmpdir|
+          input_file = File.join(tmpdir, "valid.trb")
+          File.write(input_file, "def hello: void\n  puts 'hi'\nend")
+
+          config = TRuby::Config.new
+          allow(config).to receive(:out_dir).and_return(tmpdir)
+
+          watcher = TRuby::Watcher.new(paths: [tmpdir], config: config)
+          result = watcher.send(:compile_file, input_file)
+
+          expect(result[:success]).to be true
+          expect(result[:errors]).to be_empty
+        end
+      end
+
+      it "returns error result for non-existent file" do
+        watcher = TRuby::Watcher.new(paths: ["."])
+        result = watcher.send(:compile_file, "/nonexistent/file.trb")
+
+        expect(result[:success]).to be false
+        expect(result[:errors]).not_to be_empty
+      end
+    end
+  end
+
+  describe "CLI integration" do
+    it "help text includes watch option" do
+      help = TRuby::CLI::HELP_TEXT
+      expect(help).to include("--watch")
+      expect(help).to include("-w")
+    end
+
+    it "help text includes watch examples" do
+      help = TRuby::CLI::HELP_TEXT
+      expect(help).to include("trc -w")
+      expect(help).to include("Watch")
+    end
+  end
+end

--- a/t_ruby.gemspec
+++ b/t_ruby.gemspec
@@ -16,4 +16,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "bin"
   spec.executables = ["trc"]
   spec.require_paths = ["lib"]
+
+  # Runtime dependencies
+  spec.add_dependency "listen", "~> 3.8"
 end


### PR DESCRIPTION
Implement file watching functionality similar to tsc --watch:
- Add --watch/-w CLI options for watching .trb files
- Auto-recompile on file changes with incremental compilation
- TypeScript-style terminal output with timestamps and colors
- Error reporting in familiar format: file:line:col - error TRB0001: message
- Support watching directories, single files, or current directory