### PR TITLE
fix: remove return types for methods without parentheses

### DIFF
--- a/lib/t_ruby/compiler.rb
+++ b/lib/t_ruby/compiler.rb
@@ -547,9 +547,14 @@ module TRuby
     def erase_return_types(source)
       result = source.dup
 
-      # Remove return type: ): Type or ): Type<Foo> etc.
+      # Remove return type after parentheses: ): Type or ): Type<Foo> etc.
       result.gsub!(/\)\s*:\s*[^\n]+?(?=\s*$)/m) do |_match|
         ")"
+      end
+
+      # Remove return type for methods without parentheses: def method_name: Type
+      result.gsub!(/^(\s*#{TRuby::VISIBILITY_PATTERN}def\s+#{TRuby::METHOD_NAME_PATTERN})\s*:\s*[^\n]+?(?=\s*$)/m) do |_match|
+        ::Regexp.last_match(1)
       end
 
       result

--- a/spec/t_ruby/type_erasure_spec.rb
+++ b/spec/t_ruby/type_erasure_spec.rb
@@ -157,6 +157,15 @@ describe TRuby::TypeErasure do
         expect(result).to include("def hello()")
       end
 
+      it "handles functions without parentheses and with return type" do
+        source = "def hello: String\n  'hello'\nend"
+        eraser = TRuby::TypeErasure.new(source)
+
+        result = eraser.erase
+        expect(result).to include("def hello")
+        expect(result).not_to include(": String")
+      end
+
       it "handles nested structures" do
         source = "class Greeter" + "\n  " \
                                    "def greet(name: String): String" + "\n    " \


### PR DESCRIPTION
Fix #23 