### PR TITLE
feat: implement keyword arguments syntax

### DIFF
--- a/lib/t_ruby.rb
+++ b/lib/t_ruby.rb
@@ -5,6 +5,7 @@ require_relative "t_ruby/version_checker"
 require_relative "t_ruby/config"
 
 # Core infrastructure (must be loaded first)
+require_relative "t_ruby/string_utils"
 require_relative "t_ruby/ir"
 require_relative "t_ruby/parser_combinator"
 require_relative "t_ruby/smt_solver"

--- a/lib/t_ruby/ir.rb
+++ b/lib/t_ruby/ir.rb
@@ -147,15 +147,19 @@ module TRuby
 
     # Method parameter
     class Parameter < Node
-      attr_accessor :name, :type_annotation, :default_value, :kind
+      attr_accessor :name, :type_annotation, :default_value, :kind, :interface_ref
 
-      # kind: :required, :optional, :rest, :keyrest, :block
-      def initialize(name:, type_annotation: nil, default_value: nil, kind: :required, **opts)
+      # kind: :required, :optional, :rest, :keyrest, :block, :keyword
+      # :keyword - 키워드 인자 (구조분해): { name: String } → def foo(name:)
+      # :keyrest - 더블 스플랫: **opts: Type → def foo(**opts)
+      # interface_ref - interface 참조 타입 (예: }: UserParams 부분)
+      def initialize(name:, type_annotation: nil, default_value: nil, kind: :required, interface_ref: nil, **opts)
         super(**opts)
         @name = name
         @type_annotation = type_annotation
         @default_value = default_value
         @kind = kind
+        @interface_ref = interface_ref
       end
     end
 

--- a/lib/t_ruby/string_utils.rb
+++ b/lib/t_ruby/string_utils.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module TRuby
+  # 문자열 파싱을 위한 공통 유틸리티 모듈
+  # 파서와 컴파일러에서 공유하는 중첩 괄호 처리 로직
+  module StringUtils
+    module_function
+
+    # 중첩된 괄호를 고려하여 콤마로 문자열 분리
+    # @param content [String] 분리할 문자열
+    # @return [Array<String>] 분리된 문자열 배열
+    def split_by_comma(content)
+      result = []
+      current = ""
+      depth = 0
+
+      content.each_char do |char|
+        case char
+        when "<", "[", "(", "{"
+          depth += 1
+          current += char
+        when ">", "]", ")", "}"
+          depth -= 1
+          current += char
+        when ","
+          if depth.zero?
+            result << current.strip
+            current = ""
+          else
+            current += char
+          end
+        else
+          current += char
+        end
+      end
+
+      result << current.strip unless current.empty?
+      result
+    end
+
+    # 타입과 기본값 분리: "String = 0" -> ["String", "0"]
+    # 중첩된 괄호 내부의 = 는 무시
+    # @param type_and_default [String] "Type = default" 형태의 문자열
+    # @return [Array] [type_str, default_value] 또는 [type_str, nil]
+    def split_type_and_default(type_and_default)
+      depth = 0
+      equals_pos = nil
+
+      type_and_default.each_char.with_index do |char, i|
+        case char
+        when "<", "[", "(", "{"
+          depth += 1
+        when ">", "]", ")", "}"
+          depth -= 1
+        when "="
+          if depth.zero?
+            equals_pos = i
+            break
+          end
+        end
+      end
+
+      if equals_pos
+        type_str = type_and_default[0...equals_pos].strip
+        default_value = type_and_default[(equals_pos + 1)..].strip
+        [type_str, default_value]
+      else
+        [type_and_default, nil]
+      end
+    end
+
+    # 기본값만 추출 (타입은 버림)
+    # @param type_and_default [String] "Type = default" 형태의 문자열
+    # @return [String, nil] 기본값 또는 nil
+    def extract_default_value(type_and_default)
+      _, default_value = split_type_and_default(type_and_default)
+      default_value
+    end
+  end
+end

--- a/spec/e2e/keyword_args_spec.rb
+++ b/spec/e2e/keyword_args_spec.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tempfile"
+require "fileutils"
+
+RSpec.describe "Keyword Arguments E2E" do
+  let(:tmpdir) { Dir.mktmpdir("trb_keyword_args") }
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  def create_config(lib_dir)
+    File.write(File.join(tmpdir, "trbconfig.yml"), <<~YAML)
+      emit:
+        rb: true
+        rbs: true
+        dtrb: false
+      paths:
+        src: "#{lib_dir}"
+        out: "#{lib_dir}"
+        rbs: "#{lib_dir}"
+    YAML
+
+    config = TRuby::Config.new(File.join(tmpdir, "trbconfig.yml"))
+    allow(config).to receive(:type_check?).and_return(false)
+    config
+  end
+
+  def compile_and_read(lib_dir, filename, source)
+    trb_path = File.join(lib_dir, "#{filename}.trb")
+    rb_path = File.join(lib_dir, "#{filename}.rb")
+
+    File.write(trb_path, source)
+
+    config = create_config(lib_dir)
+    compiler = TRuby::Compiler.new(config)
+    compiler.compile(trb_path)
+
+    File.read(rb_path)
+  end
+
+  describe "키워드 인자 (구조분해) - 인라인 타입" do
+    it "필수 키워드 인자를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def greet({ name: String }): String
+          "Hello, \#{name}!"
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "greet", source)
+
+      expect(result).to include("def greet(name:)")
+      expect(result).not_to include("String")
+      expect(result).to include('"Hello, #{name}!"')
+    end
+
+    it "여러 필수 키워드 인자를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def create_point({ x: Integer, y: Integer }): String
+          "(\#{x}, \#{y})"
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "point", source)
+
+      expect(result).to include("def create_point(x:, y:)")
+      expect(result).not_to include("Integer")
+    end
+
+    it "기본값이 있는 키워드 인자를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def greet_with_prefix({ name: String, prefix: String = "Hello" }): String
+          "\#{prefix}, \#{name}!"
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "greet_prefix", source)
+
+      expect(result).to include('def greet_with_prefix(name:, prefix: "Hello")')
+      expect(result).not_to include("String")
+    end
+
+    it "복잡한 타입과 기본값을 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def process_data({ items: Array = [], options: Hash = {} }): Integer
+          items.length
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "process", source)
+
+      expect(result).to include("def process_data(items: [], options: {})")
+    end
+  end
+
+  describe "키워드 인자 (구조분해) - interface 참조" do
+    it "interface 참조 키워드 인자를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        interface UserParams
+          name: String
+          age: Integer
+        end
+
+        def create_user({ name:, age: }: UserParams): String
+          "\#{name} (\#{age})"
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "user", source)
+
+      expect(result).to include("def create_user(name:, age:)")
+      expect(result).not_to include("UserParams")
+      expect(result).not_to include("interface")
+    end
+
+    it "기본값이 있는 interface 참조를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        interface ConnectionOptions
+          host: String
+          port?: Integer
+          timeout?: Integer
+        end
+
+        def connect({ host:, port: 8080, timeout: 30 }: ConnectionOptions): String
+          "\#{host}:\#{port}"
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "connect", source)
+
+      expect(result).to include("def connect(host:, port: 8080, timeout: 30)")
+    end
+  end
+
+  describe "더블 스플랫 (**opts: Type)" do
+    it "더블 스플랫 인자를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        interface LogOptions
+          message: String
+          level?: Symbol
+        end
+
+        def log(**kwargs: LogOptions): String
+          kwargs[:message]
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "log", source)
+
+      expect(result).to include("def log(**kwargs)")
+      expect(result).not_to include("LogOptions")
+    end
+  end
+
+  describe "Hash 리터럴 (config: { ... })" do
+    it "Hash 리터럴 파라미터를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def process_config(config: { host: String, port: Integer }): String
+          "\#{config[:host]}:\#{config[:port]}"
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "config", source)
+
+      expect(result).to include("def process_config(config)")
+      expect(result).not_to include("String")
+      expect(result).not_to include("Integer")
+    end
+  end
+
+  describe "위치 인자 + 키워드 인자 혼합" do
+    it "위치 인자와 키워드 인자 혼합을 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def format_name(name: String, { uppercase: Boolean = false }): String
+          uppercase ? name.upcase : name
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "format", source)
+
+      expect(result).to include("def format_name(name, uppercase: false)")
+      expect(result).not_to include("String")
+      expect(result).not_to include("Boolean")
+    end
+
+    it "여러 위치 인자와 키워드 인자를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def calculate(a: Integer, b: Integer, { round: Boolean = false }): Integer
+          result = a + b
+          round ? result.round : result
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "calc", source)
+
+      expect(result).to include("def calculate(a, b, round: false)")
+    end
+  end
+
+  describe "클래스 내부 메서드" do
+    it "클래스 내 키워드 인자 메서드를 올바르게 컴파일" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        class ApiClient
+          def initialize({ base_url: String, timeout: Integer = 30 })
+            @base_url = base_url
+            @timeout = timeout
+          end
+
+          def get({ path: String }): String
+            "\#{@base_url}\#{path}"
+          end
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "api_client", source)
+
+      expect(result).to include("def initialize(base_url:, timeout: 30)")
+      expect(result).to include("def get(path:)")
+      expect(result).not_to include("String")
+      expect(result).not_to include("Integer")
+    end
+  end
+
+  describe "기존 위치 인자 호환성" do
+    it "기존 위치 인자 문법이 여전히 작동" do
+      lib_dir = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+
+      source = <<~TRB
+        def positional_args(name: String, age: Integer = 0): String
+          "\#{name} (\#{age})"
+        end
+      TRB
+
+      result = compile_and_read(lib_dir, "positional", source)
+
+      expect(result).to include("def positional_args(name, age = 0)")
+      expect(result).not_to include("String")
+      expect(result).not_to include("Integer")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add new syntax for keyword arguments that distinguishes from positional args
- `{ name: String }` → keyword args (destructuring) → `def foo(name:)`
- `config: { host: String }` → Hash literal parameter → `def foo(config)`
- `**opts: Type` → double splat for forwarding → `def foo(**opts)`

## Changes
- Extend IR `Parameter` class with `:keyword` kind and `interface_ref`
- Add keyword args parsing in `parser.rb`
- Add keyword args code generation in `compiler.rb`
- Extract common string utilities to `StringUtils` module
- Add comprehensive e2e tests (12 test cases)

## Test plan
- [x] 12 keyword args e2e tests pass
- [x] All 100 existing e2e tests pass (5 pending)
- [x] Parser and compiler unit tests pass (59 tests)

Closes #19