### PR TITLE
chore: migrate test fixtures to new trbconfig.yml schema

### DIFF
--- a/spec/e2e/integration_spec.rb
+++ b/spec/e2e/integration_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe "T-Ruby E2E Integration" do
 
       # Create trbconfig.yml config to set output dir
       File.write(File.join(tmpdir, "trbconfig.yml"), <<~YAML)
-        emit:
-          rb: true
-          rbs: false
-          dtrb: false
-        paths:
-          src: "#{lib_dir}"
-          out: "#{lib_dir}"
+        source:
+          include:
+            - "#{lib_dir}"
+        output:
+          ruby_dir: "#{lib_dir}"
+        compiler:
+          generate_rbs: false
       YAML
 
       # Main application file
@@ -95,13 +95,13 @@ RSpec.describe "T-Ruby E2E Integration" do
 
       # Create trbconfig.yml config to set output dir
       File.write(File.join(tmpdir, "trbconfig.yml"), <<~YAML)
-        emit:
-          rb: true
-          rbs: false
-          dtrb: false
-        paths:
-          src: "#{lib_dir}"
-          out: "#{lib_dir}"
+        source:
+          include:
+            - "#{lib_dir}"
+        output:
+          ruby_dir: "#{lib_dir}"
+        compiler:
+          generate_rbs: false
       YAML
 
       # Create initial file

--- a/spec/e2e/keyword_args_spec.rb
+++ b/spec/e2e/keyword_args_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "Keyword Arguments E2E" do
 
   def create_config(lib_dir)
     File.write(File.join(tmpdir, "trbconfig.yml"), <<~YAML)
-      emit:
-        rb: true
-        rbs: true
-        dtrb: false
-      paths:
-        src: "#{lib_dir}"
-        out: "#{lib_dir}"
-        rbs: "#{lib_dir}"
+      source:
+        include:
+          - "#{lib_dir}"
+      output:
+        ruby_dir: "#{lib_dir}"
+        rbs_dir: "#{lib_dir}"
+      compiler:
+        generate_rbs: true
     YAML
 
     config = TRuby::Config.new(File.join(tmpdir, "trbconfig.yml"))

--- a/spec/t_ruby/cli_init_spec.rb
+++ b/spec/t_ruby/cli_init_spec.rb
@@ -78,7 +78,7 @@ describe TRuby::CLI do
 
     it "reports project already initialized when everything exists" do
       Dir.chdir(tmpdir) do
-        File.write("trbconfig.yml", "emit:\n  rb: true\n")
+        File.write("trbconfig.yml", "source:\n  include: [src]\n")
         Dir.mkdir("src")
         Dir.mkdir("build")
 

--- a/spec/t_ruby/compiler_spec.rb
+++ b/spec/t_ruby/compiler_spec.rb
@@ -22,12 +22,7 @@ describe TRuby::Compiler do
           input_file = File.join(tmpdir, "test.trb")
           File.write(input_file, "puts 'Hello, world!'")
 
-          # Create a custom config with output in tmpdir
-          {
-            "emit" => { "rb" => true, "rbs" => false, "dtrb" => false },
-            "paths" => { "src" => "./src", "out" => tmpdir },
-            "strict" => { "rbs_compat" => true, "null_safety" => false, "inference" => "basic" },
-          }
+          # Mock config to use tmpdir as output
           allow_any_instance_of(TRuby::Config).to receive(:out_dir).and_return(tmpdir)
           allow_any_instance_of(TRuby::Config).to receive(:src_dir).and_return("./src")
 


### PR DESCRIPTION
## Summary
- Migrate test fixtures from legacy trbconfig format to new schema

## Test plan
- [x] All existing tests pass with migrated config files

🤖 Generated with [Claude Code](https://claude.com/claude-code)