### PR TITLE
Fix Release CI workflow failure

### DIFF
--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -31,7 +31,6 @@ CORE_FILES=(
   "intersection_type_parser.rb"
   "type_erasure.rb"
   "error_handler.rb"
-  "rbs_generator.rb"
   "declaration_generator.rb"
   "compiler.rb"
   "constraint_checker.rb"


### PR DESCRIPTION
## Summary
- Remove non-existent `rbs_generator.rb` from WASM build script

## Problem
The v0.0.44 Release workflow failed because `wasm/build.sh` tried to copy `lib/t_ruby/rbs_generator.rb` which doesn't exist.

## Solution
Removed `rbs_generator.rb` from the `CORE_FILES` array in `wasm/build.sh`.

## Test
- [x] Local WASM build succeeds

Closes #42