### PR TITLE
Add tuple rest element support

### DIFF
--- a/lib/t_ruby/lsp_server.rb
+++ b/lib/t_ruby/lsp_server.rb
@@ -491,7 +491,7 @@ module TRuby
     end
 
     def type_completions
-      BUILT_IN_TYPES.map do |type|
+      completions = BUILT_IN_TYPES.map do |type|
         {
           "label" => type,
           "kind" => CompletionItemKind::CLASS,
@@ -499,6 +499,27 @@ module TRuby
           "documentation" => "T-Ruby built-in type: #{type}",
         }
       end
+
+      # Add tuple type completions
+      completions << {
+        "label" => "[T, U]",
+        "kind" => CompletionItemKind::STRUCT,
+        "detail" => "Tuple type",
+        "documentation" => "Fixed-length array with typed elements.\n\nExample: `[String, Integer]`",
+        "insertText" => "[${1:Type}, ${2:Type}]",
+        "insertTextFormat" => 2, # Snippet format
+      }
+
+      completions << {
+        "label" => "[T, *U[]]",
+        "kind" => CompletionItemKind::STRUCT,
+        "detail" => "Tuple with rest",
+        "documentation" => "Tuple with variable-length rest elements.\n\nExample: `[Header, *Row[]]`",
+        "insertText" => "[${1:Type}, *${2:Type}[]]",
+        "insertTextFormat" => 2,
+      }
+
+      completions
     end
 
     def keyword_completions
@@ -616,6 +637,20 @@ module TRuby
       # Check if it's a built-in type
       if BUILT_IN_TYPES.include?(word)
         return "**#{word}** - Built-in T-Ruby type"
+      end
+
+      # Check if it's a tuple type pattern
+      if word.match?(/^\[.*\]$/)
+        return "**Tuple Type**\n\nFixed-length array with typed elements.\n\n" \
+               "Each position can have a different type.\n\n" \
+               "Example: `[String, Integer, Boolean]`"
+      end
+
+      # Check if it's a rest element pattern
+      if word.start_with?("*") && (word.include?("[]") || word.include?("<"))
+        return "**Rest Element**\n\nVariable-length elements at the end of tuple.\n\n" \
+               "Syntax: `*Type[]` or `*Array<Type>`\n\n" \
+               "Example: `[Header, *Row[]]`"
       end
 
       # Check if it's a type alias

--- a/spec/e2e/tuple_type_spec.rb
+++ b/spec/e2e/tuple_type_spec.rb
@@ -1,0 +1,348 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tempfile"
+require "fileutils"
+require "rbs"
+
+RSpec.describe "Tuple Type E2E" do
+  let(:tmpdir) { Dir.mktmpdir("trb_tuple_e2e") }
+
+  before do
+    @original_dir = Dir.pwd
+  end
+
+  after do
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  # Helper to create config file with RBS generation enabled
+  def create_config_file(yaml_content)
+    config_path = File.join(tmpdir, "trbconfig.yml")
+    File.write(config_path, yaml_content)
+    config_path
+  end
+
+  # Helper to create a .trb file
+  def create_trb_file(relative_path, content)
+    full_path = File.join(tmpdir, relative_path)
+    FileUtils.mkdir_p(File.dirname(full_path))
+    File.write(full_path, content)
+    full_path
+  end
+
+  # Helper to compile and get RBS content
+  def compile_and_get_rbs(trb_path, rbs_dir: "sig")
+    config = TRuby::Config.new
+    allow(config).to receive(:type_check?).and_return(false)
+    compiler = TRuby::Compiler.new(config)
+    compiler.compile(trb_path)
+
+    relative_path = trb_path.sub("#{tmpdir}/src/", "")
+    rbs_path = File.join(tmpdir, rbs_dir, relative_path.sub(".trb", ".rbs"))
+    File.read(rbs_path) if File.exist?(rbs_path)
+  end
+
+  # Helper to compile and get Ruby content
+  def compile_and_get_ruby(trb_path, ruby_dir: "build")
+    config = TRuby::Config.new
+    allow(config).to receive(:type_check?).and_return(false)
+    compiler = TRuby::Compiler.new(config)
+    compiler.compile(trb_path)
+
+    relative_path = trb_path.sub("#{tmpdir}/src/", "")
+    ruby_path = File.join(tmpdir, ruby_dir, relative_path.sub(".trb", ".rb"))
+    File.read(ruby_path) if File.exist?(ruby_path)
+  end
+
+  # Helper to assert RBS is valid
+  def expect_valid_rbs(rbs_content)
+    expect(rbs_content).not_to be_nil
+    expect(rbs_content.strip).not_to be_empty
+
+    begin
+      RBS::Parser.parse_signature(rbs_content)
+    rescue RBS::ParsingError => e
+      first_line = rbs_content.strip.lines.first.to_s
+      unless first_line.start_with?("def ") || first_line.start_with?("type ")
+        raise "Generated RBS is invalid:\n#{rbs_content}\n\nParsing error: #{e.message}"
+      end
+    end
+
+    rbs_content
+  end
+
+  describe "basic tuple compilation" do
+    it "compiles basic tuple type to RBS" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/pair.trb", <<~TRB)
+          def get_pair(): [String, Integer]
+            ["hello", 42]
+          end
+        TRB
+
+        rbs_content = compile_and_get_rbs(File.join(tmpdir, "src/pair.trb"))
+
+        expect_valid_rbs(rbs_content)
+        expect(rbs_content).to include("def get_pair: () -> [String, Integer]")
+      end
+    end
+
+    it "compiles tuple parameter to RBS" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/process.trb", <<~TRB)
+          def process_pair(data: [String, Integer]): Boolean
+            true
+          end
+        TRB
+
+        rbs_content = compile_and_get_rbs(File.join(tmpdir, "src/process.trb"))
+
+        expect_valid_rbs(rbs_content)
+        expect(rbs_content).to include("def process_pair: (data: [String, Integer]) -> Boolean")
+      end
+    end
+  end
+
+  describe "tuple with rest element" do
+    it "compiles tuple with rest element to RBS (fallback to union array)" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/values.trb", <<~TRB)
+          def get_values(): [String, *Integer[]]
+            ["header", 1, 2, 3]
+          end
+        TRB
+
+        rbs_content = compile_and_get_rbs(File.join(tmpdir, "src/values.trb"))
+
+        expect_valid_rbs(rbs_content)
+        # RBS fallback: tuple with rest → union array
+        expect(rbs_content).to include("def get_values: () -> Array[String | Integer]")
+      end
+    end
+
+    it "compiles tuple with generic rest element" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/table.trb", <<~TRB)
+          def get_table(): [String, *Array<Hash>]
+            ["title", {a: 1}, {b: 2}]
+          end
+        TRB
+
+        rbs_content = compile_and_get_rbs(File.join(tmpdir, "src/table.trb"))
+
+        expect_valid_rbs(rbs_content)
+        expect(rbs_content).to include("Array[String | Hash]")
+      end
+    end
+  end
+
+  describe "nested tuple compilation" do
+    it "compiles nested tuples" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/matrix.trb", <<~TRB)
+          def get_matrix(): [[Integer, Integer], [Integer, Integer]]
+            [[1, 2], [3, 4]]
+          end
+        TRB
+
+        rbs_content = compile_and_get_rbs(File.join(tmpdir, "src/matrix.trb"))
+
+        expect_valid_rbs(rbs_content)
+        expect(rbs_content).to include("def get_matrix: () -> [[Integer, Integer], [Integer, Integer]]")
+      end
+    end
+  end
+
+  describe "type alias with tuple" do
+    it "compiles type alias with tuple" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/point.trb", <<~TRB)
+          type Point = [Integer, Integer]
+
+          def get_origin(): Point
+            [0, 0]
+          end
+        TRB
+
+        rbs_content = compile_and_get_rbs(File.join(tmpdir, "src/point.trb"))
+
+        expect_valid_rbs(rbs_content)
+        expect(rbs_content).to include("type Point = [Integer, Integer]")
+      end
+    end
+  end
+
+  describe "Ruby output type erasure" do
+    it "removes tuple types in compiled Ruby" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/typed_pair.trb", <<~TRB)
+          def get_pair(): [String, Integer]
+            ["hello", 42]
+          end
+        TRB
+
+        ruby_content = compile_and_get_ruby(File.join(tmpdir, "src/typed_pair.trb"))
+
+        expect(ruby_content).to include("def get_pair()")
+        expect(ruby_content).not_to include("[String, Integer]")
+      end
+    end
+
+    it "removes tuple with rest types in compiled Ruby" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/typed_rest.trb", <<~TRB)
+          def get_values(): [String, *Integer[]]
+            ["header", 1, 2, 3]
+          end
+        TRB
+
+        ruby_content = compile_and_get_ruby(File.join(tmpdir, "src/typed_rest.trb"))
+
+        expect(ruby_content).to include("def get_values()")
+        expect(ruby_content).not_to include("*Integer[]")
+      end
+    end
+  end
+
+  describe "error handling" do
+    it "raises error when rest element is not at end" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/bad.trb", <<~TRB)
+          def bad(): [*String[], Integer]
+            ["a", "b", 42]
+          end
+        TRB
+
+        expect do
+          compile_and_get_rbs(File.join(tmpdir, "src/bad.trb"))
+        end.to raise_error(TypeError, /Rest element must be at the end of tuple/)
+      end
+    end
+
+    it "raises error when multiple rest elements" do
+      Dir.chdir(tmpdir) do
+        create_config_file(<<~YAML)
+          source:
+            include:
+              - src
+          output:
+            ruby_dir: build
+            rbs_dir: sig
+          compiler:
+            generate_rbs: true
+        YAML
+
+        create_trb_file("src/bad_multi.trb", <<~TRB)
+          def bad(): [*String[], *Integer[]]
+            ["a", 1, 2]
+          end
+        TRB
+
+        expect do
+          compile_and_get_rbs(File.join(tmpdir, "src/bad_multi.trb"))
+        end.to raise_error(TypeError, /Tuple can have at most one rest element/)
+      end
+    end
+  end
+end

--- a/spec/t_ruby/lsp_server_spec.rb
+++ b/spec/t_ruby/lsp_server_spec.rb
@@ -243,6 +243,33 @@ RSpec.describe TRuby::LSPServer do
 
       expect(labels).to include("type", "interface", "def", "end")
     end
+
+    it "provides tuple type completions" do
+      response = send_request("textDocument/completion", {
+                                "textDocument" => { "uri" => "file:///test.trb" },
+                                "position" => { "line" => 1, "character" => 17 },
+                              })
+
+      items = response["result"]["items"]
+      labels = items.map { |i| i["label"] }
+
+      expect(labels).to include("[T, U]", "[T, *U[]]")
+    end
+
+    it "provides tuple completion with snippet format" do
+      response = send_request("textDocument/completion", {
+                                "textDocument" => { "uri" => "file:///test.trb" },
+                                "position" => { "line" => 1, "character" => 17 },
+                              })
+
+      items = response["result"]["items"]
+      tuple_item = items.find { |i| i["label"] == "[T, U]" }
+
+      expect(tuple_item).not_to be_nil
+      expect(tuple_item["detail"]).to eq("Tuple type")
+      expect(tuple_item["insertText"]).to eq("[${1:Type}, ${2:Type}]")
+      expect(tuple_item["insertTextFormat"]).to eq(2) # Snippet format
+    end
   end
 
   describe "textDocument/hover" do

--- a/spec/t_ruby/parser_combinator_spec.rb
+++ b/spec/t_ruby/parser_combinator_spec.rb
@@ -368,6 +368,35 @@ RSpec.describe TRuby::ParserCombinator do
         expect(result[:type].element_types.length).to eq(3)
       end
 
+      describe "tuple with rest element" do
+        it "parses tuple with rest element" do
+          result = parser.parse("[String, *Integer[]]")
+          expect(result[:success]).to be true
+          expect(result[:type]).to be_a(TRuby::IR::TupleType)
+          expect(result[:type].element_types.length).to eq(2)
+          expect(result[:type].element_types[1]).to be_a(TRuby::IR::TupleRestElement)
+          expect(result[:type].element_types[1].inner_type).to be_a(TRuby::IR::GenericType)
+        end
+
+        it "parses tuple with generic rest element" do
+          result = parser.parse("[Header, *Array<Row>]")
+          expect(result[:success]).to be true
+          expect(result[:type].element_types[1]).to be_a(TRuby::IR::TupleRestElement)
+        end
+
+        it "raises error when rest element is not at end" do
+          expect do
+            parser.parse("[*String[], Integer]")
+          end.to raise_error(TypeError, /Rest element must be at the end of tuple/)
+        end
+
+        it "raises error when multiple rest elements" do
+          expect do
+            parser.parse("[*String[], *Integer[]]")
+          end.to raise_error(TypeError, /Tuple can have at most one rest element/)
+        end
+      end
+
       it "parses complex nested type" do
         result = parser.parse("Map<String, Array<Tuple<Integer, String>>> | nil")
         expect(result[:success]).to be true


### PR DESCRIPTION
## Summary

- Add tuple rest element support (`[Type, *Type[]]` syntax)
- Implement `TupleRestElement` IR node
- Validate rest element position (must be at end, only one allowed)
- RBS conversion fallback to union array (RBS doesn't support tuple rest)
- LSP: tuple type completions and hover support

## Example

```ruby
# Basic tuple (existing)
[String, Integer]

# Tuple with rest element (new)
[String, *Integer[]]    # String + rest of Integers
[Header, *Row[]]        # Header + rest of Rows
```

## Test plan

- [x] Parser unit tests
- [x] IR unit tests
- [x] E2E tests
- [x] LSP completion tests
- [x] All existing tests pass

Closes #44